### PR TITLE
feat: Add Series Title Override to Anime Command

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -34,14 +34,17 @@ def parse_arguments():
     )
 
     # Subcommand: anime
-    anime_parser = subparsers.add_parser("anime", help="Standardize anime file names")
+    anime_parser = subparsers.add_parser("anime", help="Standardize anime file names.")
     arg.add_common_arguments(anime_parser)
     anime_parser.add_argument(
         "-s",
         "--season",
         type=int,
         default=0,
-        help="Season number to include in the filename",
+        help="Season number to include in the filename.",
+    )
+    anime_parser.add_argument(
+        "--title", type=str, help="Override the series title for all matched files."
     )
     anime_parser.add_argument(
         "-c",
@@ -51,20 +54,20 @@ def parse_arguments():
     )
 
     # Subcommand: movie
-    movie_parser = subparsers.add_parser("movie", help="Standardize movie file names")
+    movie_parser = subparsers.add_parser("movie", help="Standardize movie file names.")
     arg.add_common_arguments(movie_parser)
 
     # Subcommand: book
-    book_parser = subparsers.add_parser("book", help="Standardize book file names")
+    book_parser = subparsers.add_parser("book", help="Standardize book file names.")
     arg.add_common_arguments(book_parser)
 
     # Subcommand: std
     std_parser = subparsers.add_parser(
-        "std", help="Standardize file names within a directory"
+        "std", help="Standardize file names within a directory."
     )
     arg.add_common_arguments(std_parser, has_online=False)
     std_parser.add_argument(
-        "--creative", action="store_true", help="Generate random names"
+        "--creative", action="store_true", help="Generate random names."
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Overview

This pull request resolves issue #8 by introducing a `--title` argument to the `anime` command. This enhancement allows users to specify a custom series title that will be applied to all anime files processed during a single run, overriding the series name that would typically be extracted from the filenames.

## Changes made
- Introduced a new optional `--title` command-line argument for the `anime` subcommand.
- Modified the `AnimeHandler` to accept the title argument.
- Updated the renaming logic (`_rename_anime_file`) to prioritize the `title` argument for the `series_name` if provided; otherwise, it falls back to the series name extracted from the filename.
- Ensured that other metadata, such as season number, episode number, and episode title, are still parsed from the original filenames.
- Adjusted internal methods (`_process_anime_files`, `handle`) to correctly pass and utilize the new `series_title_override`.
- Improved the skip message in `_rename_anime_file` to be more specific about missing information (series name or episode number).
